### PR TITLE
Fixed for #1

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,6 +57,15 @@ module.exports = function(grunt) {
           outputDir: 'tmp/override'
         }
       },
+      target_contains_repo: {
+        options: {
+          env: 'production',
+          files: [
+              'test/fixtures/target_contains_repo/package.json'
+          ],
+          outputDir: 'tmp/target_contains_repo'
+        }
+      },
       missing: {
         options: {
           env: 'none',

--- a/tasks/dependency_mapper.js
+++ b/tasks/dependency_mapper.js
@@ -56,11 +56,26 @@ module.exports = function (grunt) {
                             var target_value = environments[options.env];
                             var current_value = package_json[dependency_collection][dependency_name];
 
-                            if (current_value.length > 0 && target_value.indexOf('#') > 0) {
-                                grunt.log.warn("Branch/Tag Specified in Target Repository (" + target_value.substr(target_value.indexOf('#')+1) + ") will be overridden by (" + current_value + ")")
-                                package_json[dependency_collection][dependency_name] = target_value.substr(0,target_value.indexOf('#')+1) + current_value;
+                            var current_value_contains_branch = true;
+                            for (var e in environments) {
+                                if (environments.hasOwnProperty(e)) {
+                                    grunt.log.writeln("Checking if " + current_value + " contains " + environments[e]);
+                                    if (current_value.indexOf(environments[e]) > -1) {
+
+                                        current_value_contains_branch = false;
+                                    }
+                                }
+                            }
+
+                            if (current_value_contains_branch) {
+                                if (current_value.length > 0 && target_value.indexOf('#') > 0) {
+                                    grunt.log.warn("Branch/Tag Specified in Target Repository (" + target_value.substr(target_value.indexOf('#') + 1) + ") will be overridden by (" + current_value + ")")
+                                    package_json[dependency_collection][dependency_name] = target_value.substr(0, target_value.indexOf('#') + 1) + current_value;
+                                } else {
+                                    package_json[dependency_collection][dependency_name] = target_value + (current_value.length > 0 ? "#" + current_value : "");
+                                }
                             } else {
-                                package_json[dependency_collection][dependency_name] = target_value + (current_value.length > 0 ? "#" + current_value : "");
+                                package_json[dependency_collection][dependency_name] = target_value;
                             }
 
                             grunt.log.writeln("Set '" + dependency_name + "' to pull from '" + package_json[dependency_collection][dependency_name]);

--- a/test/dependency_mapper_test.js
+++ b/test/dependency_mapper_test.js
@@ -54,6 +54,15 @@ exports.dependency_mapper = {
 
     test.done();
   },
+  target_contains_repo: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/target_contains_repo/package.json');
+    var expected = grunt.file.read('test/expected/target_contains_repo/package.json');
+    test.equal(actual, expected, 'should replace the repo with the specified one');
+
+    test.done();
+  },
   missing: function(test) {
     test.expect(1);
 

--- a/test/expected/target_contains_repo/package.json
+++ b/test/expected/target_contains_repo/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "test",
+  "version": "0.1.0",
+  "dependencies": {
+    "custom.dependency": "git+ssh://github.com/custom.dependency#master"
+  },
+  "dependency_map": {
+    "custom.dependency": {
+      "development": "git+ssh://github.com/custom.dependency#develop",
+      "ci": "git+ssh://github.com/custom.dependency#ci",
+      "production": "git+ssh://github.com/custom.dependency#master"
+    }
+  }
+}

--- a/test/fixtures/target_contains_repo/package.json
+++ b/test/fixtures/target_contains_repo/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "test",
+  "version": "0.1.0",
+  "dependencies": {
+    "custom.dependency": "git+ssh://github.com/custom.dependency#develop"
+  },
+  "dependency_map": {
+    "custom.dependency": {
+      "development": "git+ssh://github.com/custom.dependency#develop",
+      "ci": "git+ssh://github.com/custom.dependency#ci",
+      "production": "git+ssh://github.com/custom.dependency#master"
+    }
+  }
+}


### PR DESCRIPTION
Added check to see if the `current_value` contains and of the repositories listed in the dependency map and if so, replace the entire string rather than assuming anything in the dependency value represents a branch/tag to append to the url.
